### PR TITLE
Implement initial Monograph metadata fields

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -55,6 +55,12 @@ class CatalogController < ApplicationController
     config.add_index_field solr_name('human_readable_type', :stored_searchable)
     config.add_index_field solr_name('format', :stored_searchable)
     config.add_index_field solr_name('identifier', :stored_searchable)
+    # Heliotrope
+    config.add_index_field solr_name('date', :stored_searchable)
+    config.add_index_field solr_name('isbn', :stored_searchable)
+    config.add_index_field solr_name('editor', :stored_searchable)
+    config.add_index_field solr_name('copyright_holder', :stored_searchable)
+    config.add_index_field solr_name('buy_URL', :symbol)
 
     # "fielded" search configuration. Used by pulldown among other places.
     # For supported keys in hash, see rdoc for Blacklight::SearchFields

--- a/app/forms/curation_concerns/monograph_form.rb
+++ b/app/forms/curation_concerns/monograph_form.rb
@@ -3,5 +3,6 @@
 module CurationConcerns
   class MonographForm < CurationConcerns::Forms::WorkForm
     self.model_class = ::Monograph
+    self.terms += [:date, :isbn, :editor, :copyright_holder, :buy_URL]
   end
 end

--- a/app/models/monograph.rb
+++ b/app/models/monograph.rb
@@ -4,4 +4,22 @@ class Monograph < ActiveFedora::Base
   include ::CurationConcerns::WorkBehavior
   include ::CurationConcerns::BasicMetadata
   validates :title, presence: { message: 'Your work must have a title.' }
+
+  # Move this into its own concern later?
+  # RDF predicates are not mapped correctly
+  property :date, predicate: ::RDF::URI.new('http://schema.org/datePublished') do |index|
+    index.as :stored_searchable
+  end
+  property :isbn, predicate: ::RDF::URI.new('http://schema.org/isbn') do |index|
+    index.as :stored_searchable
+  end
+  property :editor, predicate: ::RDF::URI.new('http://schema.org/editor') do |index|
+    index.as :stored_searchable
+  end
+  property :copyright_holder, predicate: ::RDF::URI.new('http://schema.org/copyrightHolder') do |index|
+    index.as :stored_searchable
+  end
+  property :buy_URL, predicate: ::RDF::URI.new('http://schema.org/sameAs') do |index|
+    index.as :symbol
+  end
 end

--- a/app/views/curation_concerns/base/_form_additional_information.html.erb
+++ b/app/views/curation_concerns/base/_form_additional_information.html.erb
@@ -1,0 +1,12 @@
+<fieldset class="optional prompt">
+  <legend>Additional Information</legend>
+  <%= f.input :subject,                as: :multi_value, input_html: { class: 'form-control' } %>
+  <%= f.input :publisher,              as: :multi_value, input_html: { class: 'form-control' } %>
+  <%= f.input :date %>
+  <%= f.input :source,                 as: :multi_value, input_html: { class: 'form-control' } %>
+  <%= f.input :language,               as: :multi_value, input_html: { class: 'form-control' } %>
+  <%= f.input :isbn,                   as: :multi_value, input_html: { class: 'form-control' }, label: 'ISBN' %>
+  <%= f.input :editor,                 as: :multi_value, input_html: { class: 'form-control' }, label: 'Editor' %>
+  <%= f.input :copyright_holder,       as: :multi_value, input_html: { class: 'form-control' }, label: 'Copyright Holder' %>
+  <%= f.input :buy_URL,                as: :multi_value, input_html: { class: 'form-control' }, label: 'Buy URL' %>
+</fieldset>

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -1,3 +1,11 @@
 en:
   blacklight:
     application_name: 'Blacklight'
+
+    search:
+      fields:
+        date_tesim: "Date"
+        isbn_tesim: "ISBN"
+        editor_tesim: "Editor"
+        copyright_holder_tesim: "Copyright Holder"
+        buy_URL_ssim: "Buy Book"


### PR DESCRIPTION
A first pass at #53. Adds initial Monograph metadata fields to the Monograph controller,
model, and to the catalog view and the create/edit form. Overrides
default labels of initial metadata fields with human readable labels.