### PR TITLE
Don't set monograph on a Section unless the id is present

### DIFF
--- a/app/actors/curation_concerns/section_actor.rb
+++ b/app/actors/curation_concerns/section_actor.rb
@@ -5,10 +5,18 @@ module CurationConcerns
     protected
 
       def apply_save_data_to_curation_concern
-        monograph = Monograph.find(attributes.delete('monograph_id'))
-        super
-        monograph.members << curation_concern
-        monograph.save!
+        maybe_set_monograph do
+          super
+        end
+      end
+
+      def maybe_set_monograph
+        monograph = Monograph.find(attributes.delete('monograph_id')) if attributes.key?('monograph_id')
+        yield
+        if monograph
+          monograph.ordered_members << curation_concern
+          monograph.save!
+        end
       end
   end
 end

--- a/app/forms/curation_concerns/section_form.rb
+++ b/app/forms/curation_concerns/section_form.rb
@@ -2,7 +2,7 @@ module CurationConcerns
   class SectionForm < CurationConcerns::Forms::WorkForm
     self.model_class = ::Section
 
-    self.terms = [:title, :monograph_id]
+    self.terms = [:title, :monograph_id, :ordered_member_ids]
     self.required_fields = [:title, :monograph_id]
     # :files, :visibility_during_embargo, :embargo_release_date, :visibility_after_embargo, :visibility_during_lease, :lease_expiration_date, :visibility_after_lease, :visibility, :ordered_member_ids]
   end

--- a/spec/actors/curation_concerns/section_actor_spec.rb
+++ b/spec/actors/curation_concerns/section_actor_spec.rb
@@ -2,19 +2,35 @@ require 'rails_helper'
 
 describe CurationConcerns::SectionActor do
   let(:user) { create(:user) }
-  let(:curation_concern) { Section.new }
   let(:actor) do
     described_class.new(curation_concern, user, attributes)
   end
 
   describe "#create" do
+    let(:curation_concern) { Section.new }
     let(:monograph) { create(:monograph) }
     let(:attributes) { { title: ["This is a title."],
                          monograph_id: monograph.id } }
 
     it 'adds the section to the monograph' do
       expect(actor.create).to be true
-      expect(monograph.reload.members.size).to eq 1
+      expect(monograph.reload.ordered_members.to_a.size).to eq 1
+    end
+  end
+
+  describe "reorder the attached files" do
+    let(:curation_concern) { create(:section) }
+    let!(:file_set1) { create(:file_set) }
+    let!(:file_set2) { create(:file_set) }
+    before do
+      curation_concern.ordered_members << file_set1
+      curation_concern.ordered_members << file_set2
+      curation_concern.save!
+    end
+    let(:attributes) { { ordered_member_ids: [file_set2.id, file_set1.id] } }
+    it 'sets the order of the files in the section' do
+      expect(actor.update).to be true
+      expect(curation_concern.reload.ordered_member_ids).to eq [file_set2.id, file_set1.id]
     end
   end
 end

--- a/spec/factories/file_sets.rb
+++ b/spec/factories/file_sets.rb
@@ -1,0 +1,18 @@
+FactoryGirl.define do
+  factory :file_set do
+    transient do
+      user { FactoryGirl.create(:user) }
+    end
+
+    after(:build) do |work, evaluator|
+      work.apply_depositor_metadata(evaluator.user.user_key)
+    end
+
+    sequence(:title) { |n| ["Test FileSet #{n}"] }
+    visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+
+    factory :public_file_set do
+      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+    end
+  end
+end

--- a/spec/factories/sections.rb
+++ b/spec/factories/sections.rb
@@ -1,0 +1,18 @@
+FactoryGirl.define do
+  factory :section do
+    transient do
+      user { FactoryGirl.create(:user) }
+    end
+
+    after(:build) do |work, evaluator|
+      work.apply_depositor_metadata(evaluator.user.user_key)
+    end
+
+    sequence(:title) { |n| ["Test Section #{n}"] }
+    visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+
+    factory :public_section do
+      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+    end
+  end
+end

--- a/spec/forms/curation_concerns/section_form_spec.rb
+++ b/spec/forms/curation_concerns/section_form_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe CurationConcerns::SectionForm do
   describe "#terms" do
     subject { described_class.terms }
-    it { is_expected.to eq [:title, :monograph_id] }
+    it { is_expected.to eq [:title, :monograph_id, :ordered_member_ids] }
   end
 
   describe "#required_fields" do


### PR DESCRIPTION
Previously the reorder file_sets UI was broken because it was attempting
to do a lookup for a monograph with a nil id.