### PR TITLE
Persist minter-state for development enviornments

### DIFF
--- a/config/curation_concerns.yml.sample
+++ b/config/curation_concerns.yml.sample
@@ -9,6 +9,7 @@ default: &default
 
 development:
   <<: *default
+  minter_path: <%= File.join(Rails.root, 'tmp', 'minter-state') %>
 
 test:
   <<: *default


### PR DESCRIPTION
Moving minter-state from system /tmp which gets erased every boot to project ./tmp subdirectory so minter-state will persist in dev environments.