### PR TITLE
Settings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,8 @@ gem 'puma'
 # gem 'sqlite3'
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 5.0'
+# use config gem to pull in settings from .yml files
+gem 'config'
 # Use Uglifier as compressor for JavaScript assets
 gem 'uglifier', '>= 1.3.0'
 # Use CoffeeScript for .coffee assets and views

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,6 +156,9 @@ GEM
       execjs
     coffee-script-source (1.10.0)
     concurrent-ruby (1.0.1)
+    config (1.1.0)
+      activesupport (>= 3.0)
+      deep_merge (~> 1.0.1)
     curation_concerns (0.12.0.pre9)
       active-fedora (~> 9.9)
       active_attr
@@ -181,6 +184,7 @@ GEM
       sprockets-es6
     daemons (1.2.3)
     debug_inspector (0.0.2)
+    deep_merge (1.0.1)
     deprecation (0.2.2)
       activesupport
     devise (3.5.6)
@@ -569,6 +573,7 @@ DEPENDENCIES
   capistrano-rbenv (~> 2.0)
   capybara
   coffee-rails (~> 4.1.0)
+  config
   curation_concerns (= 0.12.0.pre9)
   devise
   devise-guests (~> 0.3)

--- a/bin/setup
+++ b/bin/setup
@@ -15,7 +15,7 @@ Dir.chdir APP_ROOT do
   system "bundle check || bundle install"
 
   puts "\n== Copying sample files =="
-  files = ['secrets', 'database', 'curation_concerns']
+  files = ['secrets', 'database']
   files.each do |f|
     yml_name = "config/#{f}.yml"
     cp "#{yml_name}.sample", yml_name unless File.exist?(yml_name)

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -18,7 +18,6 @@ set :keep_releases, 5
 set :linked_files,
     %w(
       config/blacklight.yml
-      config/curation_concerns.yml
       config/database.yml
       config/fedora.yml
       config/redis.yml
@@ -31,6 +30,7 @@ set :linked_files,
 # Default value for linked_dirs is []
 set :linked_dirs,
     %w(
+      config/settings
       log
       tmp
     )

--- a/config/initializers/config.rb
+++ b/config/initializers/config.rb
@@ -1,0 +1,7 @@
+Config.setup do |config|
+  # Name of the constat exposing loaded settings
+  config.const_name = 'Settings'
+
+  # Ability to remove elements of the array set in earlier loaded settings file. Default: nil
+  # config.knockout_prefix = '--'
+end

--- a/config/initializers/curation_concerns.rb
+++ b/config/initializers/curation_concerns.rb
@@ -1,6 +1,4 @@
 CurationConcerns.configure do |config|
-  # use the yaml file for server config settings - derivatives, uploads, & minter-state
-  yaml = YAML.load(ERB.new(IO.read(File.join(Rails.root, 'config', 'curation_concerns.yml'))).result)[Rails.env].with_indifferent_access
   # Injected via `rails g curation_concerns:work Section`
   config.register_curation_concern :section
   # Injected via `rails g curation_concerns:work Monograph`
@@ -31,12 +29,12 @@ CurationConcerns.configure do |config|
 
   # Location on local file system where derivatives will be stored.
   # If you use a multi-server architecture, this MUST be a shared volume.
-  config.derivatives_path = yaml["derivatives_path"]
+  config.derivatives_path = Settings.derivatives_path
 
   # Location on local file system where uploaded files will be staged
   # prior to being ingested into the repository or having derivatives generated.
   # If you use a multi-server architecture, this MUST be a shared volume.
-  config.working_path = yaml["uploads_path"]
+  config.working_path = Settings.uploads_path
 
   # If you have ffmpeg installed and want to transcode audio and video uncomment this line
   config.enable_ffmpeg = true
@@ -50,7 +48,7 @@ CurationConcerns.configure do |config|
 
   # Store identifier minter's state in a file for later replayability
   # If you use a multi-server architecture, this MUST be on a shared volume.
-  config.minter_statefile = yaml["minter_path"]
+  config.minter_statefile = Settings.minter_path
 
   # Specify the prefix for Redis keys:
   # config.redis_namespace = "curation_concerns"

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,0 +1,8 @@
+  # settings for curation concerns in a developemnt environment:
+  # derivatives_path contains thumbnails and web-friendly audio, and video files for playbock
+  derivatives_path: <%= File.join(Rails.root, 'tmp', 'derivatives') %>
+  # uploads_path stashes files uploaded via the browser before ingest to fedora
+  # on distributed architectures, uploads_path must be on a drive shared with the web server
+  uploads_path: <%= File.join(Rails.root, 'tmp', 'uploads') %>
+  # minter_path tracks the ID of the last-created object
+  minter_path: <%= File.join(Rails.root, 'tmp', 'minter-state') %>

--- a/config/settings/production.yml.sample
+++ b/config/settings/production.yml.sample
@@ -1,0 +1,20 @@
+  # sample settings for curation concerns in a production environment:
+  #
+  # derivatives_path contains thumbnails and web-friendly audio, and video files for playbock
+  # for production, put this in a non-temporary location:
+  # derivatives_path: <%= File.join(Rails.root, 'derivatives') %>
+  # or
+  # derivatives_path: /opt/derivatives
+  #
+  #
+  # uploads_path stashes files uploaded via the browser before ingest to fedora
+  # on distributed architectures, uploads_path must be on a drive shared with the web server
+  # in production, have a way of periodically clearing out this directory
+  # uploads_path: <%= File.join(Rails.root, 'uploads') %>
+  #
+  #
+  # minter_path tracks the ID of the last-created object
+  # for production, put this in a non-temporary location:
+  # minter_path: <%= File.join(Rails.root, 'minter-state') %>
+  # or 
+  # minter_path: /opt/minter-state

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,4 +1,4 @@
-default: &default
+  # settings for curation concerns for the test environment, locally and on Travis:
   # derivatives_path contains thumbnails and web-friendly audio, and video files for playbock
   derivatives_path: <%= File.join(Rails.root, 'tmp', 'derivatives') %>
   # uploads_path stashes files uploaded via the browser before ingest to fedora
@@ -6,16 +6,3 @@ default: &default
   uploads_path: <%= File.join(Rails.root, 'tmp', 'uploads') %>
   # minter_path tracks the ID of the last-created object
   minter_path: <%= File.join(Rails.root, 'tmp', 'minter-state') %>
-
-development:
-  <<: *default
-
-test:
-  <<: *default
-
-production:
-  <<: *default
-  # we recommend setting derivatives_path and the minter_path
-  # to persistent (non-temporary) locations for production systems
-  derivatives_path: <%= File.join(Rails.root, 'derivatives')
-  minter_path: <%= File.join(Rails.root, 'minter-state')


### PR DESCRIPTION
This changeset will get rid of the custom load-yaml-file code in `config/initializers/curation_concerns.rb`. In return it introduces a new level of config: `config/settings/<env>.yml` instead of `config/curation_concerns.yml`.
I would prefer to to consolidate the settings into a config/settings.yml with defaults and all the environments (like we do in `database.yml`, etc.). @val99erie helped me search for a consolidated solution. Using the `send` method (e.g. `config.derivatives_path = Settings.send(Rails.env).derivatives_path`) made the test suite fail due to a pre-existing method `test`. Adding `settings = eval "Settings.#{Rails.env}"` offended rubocop and seemed like a dangerous precedent. So falling back on this more diffuse solution.
If/when we merge this PR, we need to update the configuration on all machines running in production mode.
Closes #91. 