### PR TITLE
Section access rights 81

### DIFF
--- a/app/actors/curation_concerns/section_actor.rb
+++ b/app/actors/curation_concerns/section_actor.rb
@@ -14,6 +14,8 @@ module CurationConcerns
         if monograph
           monograph.ordered_members << curation_concern
           monograph.save!
+          # Story #81, section should have the same visibility as it's monograph
+          curation_concern.visibility = monograph.visibility
         end
       end
   end

--- a/app/actors/curation_concerns/section_actor.rb
+++ b/app/actors/curation_concerns/section_actor.rb
@@ -14,8 +14,8 @@ module CurationConcerns
         if monograph
           monograph.ordered_members << curation_concern
           monograph.save!
-          # Story #81, section should have the same visibility as it's monograph
-          curation_concern.visibility = monograph.visibility
+          # Story #81, section should have the same visibility as it's monograph by default
+          curation_concern.visibility = monograph.visibility unless attributes.key?('visibility')
         end
       end
   end

--- a/app/forms/curation_concerns/section_form.rb
+++ b/app/forms/curation_concerns/section_form.rb
@@ -2,7 +2,16 @@ module CurationConcerns
   class SectionForm < CurationConcerns::Forms::WorkForm
     self.model_class = ::Section
 
-    self.terms = [:title, :monograph_id, :ordered_member_ids]
+    self.terms = [:title,
+                  :monograph_id,
+                  :ordered_member_ids,
+                  :visibility_during_embargo,
+                  :embargo_release_date,
+                  :visibility_after_embargo,
+                  :visibility_during_lease,
+                  :lease_expiration_date,
+                  :visibility_after_lease,
+                  :visibility]
     self.required_fields = [:title, :monograph_id]
     # :files, :visibility_during_embargo, :embargo_release_date, :visibility_after_embargo, :visibility_during_lease, :lease_expiration_date, :visibility_after_lease, :visibility, :ordered_member_ids]
   end

--- a/app/views/curation_concerns/sections/_form_supplementary_fields.html.erb
+++ b/app/views/curation_concerns/sections/_form_supplementary_fields.html.erb
@@ -1,1 +1,5 @@
-<% # displays nothing %>
+<div class="row with-headroom">
+  <div class="col-md-12">
+    <%= render "form_permission", f: f %>
+  </div>
+</div>

--- a/spec/actors/curation_concerns/section_actor_spec.rb
+++ b/spec/actors/curation_concerns/section_actor_spec.rb
@@ -16,6 +16,10 @@ describe CurationConcerns::SectionActor do
     let(:attributes) { { title: ["This is a title."],
                          monograph_id: monograph.id } }
 
+    let(:private_attributes) { { title: ["This is a private section title."],
+                                 monograph_id: monograph.id,
+                                 visibility: 'restricted' } }
+
     it 'adds the section to the monograph' do
       expect(actor.create(attributes)).to be true
       expect(monograph.reload.ordered_members.to_a.size).to eq 1
@@ -24,6 +28,11 @@ describe CurationConcerns::SectionActor do
     it "adds the monograph visibility to the section" do
       expect(actor.create(attributes)).to be true
       expect(Section.first.visibility).to eq monograph.visibility
+    end
+
+    it "adds the section visibility to the section" do
+      expect(actor.create(private_attributes)).to be true
+      expect(Section.first.visibility).to eq 'restricted'
     end
   end
 

--- a/spec/actors/curation_concerns/section_actor_spec.rb
+++ b/spec/actors/curation_concerns/section_actor_spec.rb
@@ -1,19 +1,29 @@
 require 'rails_helper'
 
 describe CurationConcerns::SectionActor do
+  before do
+    Section.destroy_all
+    Monograph.destroy_all
+  end
+
   let(:user) { create(:user) }
   let(:list_of_actors) { [described_class] }
   let(:actor) { CurationConcerns::ActorStack.new(curation_concern, user, list_of_actors) }
 
   describe "#create" do
     let(:curation_concern) { Section.new }
-    let(:monograph) { create(:monograph) }
+    let(:monograph) { create(:public_monograph) }
     let(:attributes) { { title: ["This is a title."],
                          monograph_id: monograph.id } }
 
     it 'adds the section to the monograph' do
       expect(actor.create(attributes)).to be true
       expect(monograph.reload.ordered_members.to_a.size).to eq 1
+    end
+
+    it "adds the monograph visibility to the section" do
+      expect(actor.create(attributes)).to be true
+      expect(Section.first.visibility).to eq monograph.visibility
     end
   end
 

--- a/spec/forms/curation_concerns/section_form_spec.rb
+++ b/spec/forms/curation_concerns/section_form_spec.rb
@@ -3,7 +3,16 @@ require 'rails_helper'
 describe CurationConcerns::SectionForm do
   describe "#terms" do
     subject { described_class.terms }
-    it { is_expected.to eq [:title, :monograph_id, :ordered_member_ids] }
+    it { is_expected.to eq [:title,
+                            :monograph_id,
+                            :ordered_member_ids,
+                            :visibility_during_embargo,
+                            :embargo_release_date,
+                            :visibility_after_embargo,
+                            :visibility_during_lease,
+                            :lease_expiration_date,
+                            :visibility_after_lease,
+                            :visibility] }
   end
 
   describe "#required_fields" do


### PR DESCRIPTION
Sections should have visibility controls the same ways monographs do. New sections will use this visibility, or if it doesn't have one, will default to the same visibility as it's monograph.

This resolves #81