### PR TITLE
Updating a section doesn't re-add it to monograph.ordered_members, #178

### DIFF
--- a/app/actors/curation_concerns/section_actor.rb
+++ b/app/actors/curation_concerns/section_actor.rb
@@ -11,7 +11,7 @@ module CurationConcerns
       def maybe_set_monograph(attributes)
         monograph = Monograph.find(attributes.delete('monograph_id')) if attributes.key?('monograph_id')
         yield
-        if monograph
+        if monograph && !monograph.ordered_members.to_a.include?(curation_concern)
           monograph.ordered_members << curation_concern
           monograph.save!
           # Story #81, section should have the same visibility as it's monograph by default

--- a/spec/actors/curation_concerns/section_actor_spec.rb
+++ b/spec/actors/curation_concerns/section_actor_spec.rb
@@ -36,6 +36,22 @@ describe CurationConcerns::SectionActor do
     end
   end
 
+  describe "#update" do
+    let(:curation_concern) { Section.new }
+    let(:monograph) { create(:monograph) }
+    let(:attributes) { { title: ["This is a section title."],
+                         monograph_id: monograph.id } }
+
+    # bug #178
+    it "does not re-add the section to monograph.ordered_members on update" do
+      expect(actor.create(attributes)).to be true
+      expect(monograph.reload.ordered_members.to_a.size).to eq 1
+
+      expect(actor.update(attributes)).to be true
+      expect(monograph.reload.ordered_members.to_a.size).to eq 1
+    end
+  end
+
   # TODO: Write a higher-level test for re-ordering the files
   # that are attached to a section.  This is no longer the right
   # place to test that behavior because the ordering is no


### PR DESCRIPTION
resolves #178 