### PR TITLE
Add code to list view partial sources in development mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,18 @@ Or, if you prefer to start each server individually:
   $ bundle exec bin/rails s
 ```
 
+### Explain Partials
+
+Set the EXPLAIN_PARTIALS environment variable to show partials being rendered in source html of your views
+(view this info using your browser's inspect element mode)
+
+```
+$ EXPLAIN_PARTIALS=true bundle exec bin/rails s
+```
+
+*NOTE:* Because this feature can add a fair bit of overhead, it is restricted 
+to only run in development mode.
+
 ## Testing
 
 run `rake ci`

--- a/config/initializers/explain_partials.rb
+++ b/config/initializers/explain_partials.rb
@@ -1,0 +1,16 @@
+# Start the app with EXPLAIN_PARTIALS=true to show locations of view partials
+if Rails.env.development? && ENV['EXPLAIN_PARTIALS']
+  module ActionView
+    class PartialRenderer
+      def render_with_explanation(*args)
+        rendered = render_without_explanation(*args).to_s
+        # Note: We haven't figured out how to get a path when @template is nil.
+        start_explanation = "\n<!-- START PARTIAL #{@template.inspect} -->\n"
+        end_explanation = "\n<!-- END PARTIAL #{@template.inspect} -->\n"
+        start_explanation.html_safe + rendered + end_explanation.html_safe
+      end
+
+      alias_method_chain :render, :explanation
+    end
+  end
+end


### PR DESCRIPTION
Set the environement variable EXPLAIN_PARTIALS=true before
starting your rails server in development mode to have additional
comments included in your HTML source that show the file corresponding
to each partial being rendered.

Closes #198