### PR TITLE
mount resque-web for platform admins

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,8 @@ gem 'rails', '4.2.6'
 
 gem 'curation_concerns', '0.12.0'
 gem 'active-fedora', '9.10.4'
+gem 'resque-web', '~> 0.0.7', require: 'resque_web'
+gem 'resque'
 # gem 'pg', '0.18.4'
 gem 'mysql2'
 gem 'puma'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,6 +155,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.10.0)
+    commonjs (0.2.7)
     concurrent-ruby (1.0.1)
     config (1.1.0)
       activesupport (>= 3.0)
@@ -281,6 +282,13 @@ GEM
       linkeddata (>= 1.1)
       rdf-vocab
       slop
+    less (2.6.0)
+      commonjs (~> 0.2.7)
+    less-rails (2.7.1)
+      actionpack (>= 4.0)
+      less (~> 2.6.0)
+      sprockets (> 2, < 4)
+      tilt
     libv8 (3.16.14.13)
     link_header (0.0.8)
     linkeddata (1.99.0)
@@ -450,6 +458,12 @@ GEM
     resque-pool (0.6.0)
       rake
       resque (~> 1.22)
+    resque-web (0.0.7)
+      coffee-rails
+      jquery-rails
+      resque
+      sass-rails
+      twitter-bootstrap-rails
     rsolr (1.0.13)
       builder (>= 2.1.2)
     rspec-core (3.4.4)
@@ -539,6 +553,11 @@ GEM
     tilt (2.0.2)
     turbolinks (2.5.3)
       coffee-rails
+    twitter-bootstrap-rails (3.2.2)
+      actionpack (>= 3.1)
+      execjs (>= 2.2.2, >= 2.2)
+      less-rails (>= 2.5.0)
+      railties (>= 3.1)
     twitter-typeahead-rails (0.11.1)
       actionpack (>= 3.1)
       jquery-rails
@@ -585,6 +604,8 @@ DEPENDENCIES
   net-ssh-krb!
   puma
   rails (= 4.2.6)
+  resque
+  resque-web (~> 0.0.7)
   rsolr (~> 1.0.6)
   rspec-rails
   rubocop (~> 0.37.2)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,13 @@
 Rails.application.routes.draw do
   mount Blacklight::Engine => '/'
+  resque_web_constraint = lambda do |request|
+    current_user = request.env['warden'].user
+    current_user.present? && current_user.respond_to?(:platform_admin?) && current_user.platform_admin?
+  end
+
+  constraints resque_web_constraint do
+    mount ResqueWeb::Engine => '/resque'
+  end
 
   concern :searchable, Blacklight::Routes::Searchable.new
 


### PR DESCRIPTION
Addresses the first acceptance criterion of #197. Only platform admins can access the resque-web console at /resque; other users currently get 500 errors. See also #207. 