### PR TITLE
add the monograph's id to its section(s) for #187

### DIFF
--- a/app/actors/curation_concerns/section_actor.rb
+++ b/app/actors/curation_concerns/section_actor.rb
@@ -14,8 +14,9 @@ module CurationConcerns
         if monograph && !monograph.ordered_members.to_a.include?(curation_concern)
           monograph.ordered_members << curation_concern
           monograph.save!
-          # Story #81, section should have the same visibility as it's monograph by default
+
           curation_concern.visibility = monograph.visibility unless attributes.key?('visibility')
+          curation_concern.monograph_id = monograph.id
         end
       end
   end

--- a/app/forms/curation_concerns/section_form.rb
+++ b/app/forms/curation_concerns/section_form.rb
@@ -12,6 +12,7 @@ module CurationConcerns
                   :lease_expiration_date,
                   :visibility_after_lease,
                   :visibility]
+
     self.required_fields = [:title, :monograph_id]
     # :files, :visibility_during_embargo, :embargo_release_date, :visibility_after_embargo, :visibility_during_lease, :lease_expiration_date, :visibility_after_lease, :visibility, :ordered_member_ids]
   end

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -2,9 +2,15 @@ class Section < ActiveFedora::Base
   include ::CurationConcerns::WorkBehavior
   include ::CurationConcerns::BasicMetadata
   include GlobalID::Identification
+
   validates :title, presence: { message: 'Your work must have a title.' }
 
   property :date_published, predicate: ::RDF::Vocab::SCHEMA.datePublished do |index|
     index.as :stored_searchable
+  end
+
+  # TODO: is SCHEMA.isPartOf ok for the Section's monograph_id?
+  property :monograph_id, predicate: ::RDF::Vocab::SCHEMA.isPartOf, multiple: false do |index|
+    index.as :symbol
   end
 end

--- a/app/views/curation_concerns/sections/_form_descriptive_fields.erb
+++ b/app/views/curation_concerns/sections/_form_descriptive_fields.erb
@@ -3,7 +3,7 @@
     <fieldset class="required">
       <legend>Required Information</legend>
       <%= f.input :title, as: :multi_value %>
-      <%= f.input :monograph_id, collection: Monograph.all.map { |b| [b.title.first, b.id] } %>
+      <%= f.input :monograph_id, collection: Monograph.all.map { |b| [b.title.first, b.id] }, selected: @form.monograph_id %>
     </fieldset>
   </div>
 </div>

--- a/spec/actors/curation_concerns/section_actor_spec.rb
+++ b/spec/actors/curation_concerns/section_actor_spec.rb
@@ -34,6 +34,11 @@ describe CurationConcerns::SectionActor do
       expect(actor.create(private_attributes)).to be true
       expect(Section.first.visibility).to eq 'restricted'
     end
+
+    it "adds the monograph_id to the section" do
+      expect(actor.create(attributes)).to be true
+      expect(Section.first.monograph_id).to eq monograph.id
+    end
   end
 
   describe "#update" do

--- a/spec/features/edit_section_spec.rb
+++ b/spec/features/edit_section_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+feature 'Edit a section' do
+  context 'a logged in user' do
+    before do
+      Section.destroy_all
+      Monograph.destroy_all
+    end
+    let(:user) { create(:platform_admin) }
+    let!(:monograph1) { create(:monograph, user: user) }
+    let!(:monograph2) { create(:monograph, user: user) }
+    let!(:monograph3) { create(:monograph, user: user) }
+    let!(:section) { create(:section, monograph_id: monograph2.id) }
+    before do
+      login_as user
+    end
+
+    scenario "the section's monograph is pre-selected in the monograph dropdown" do
+      visit edit_curation_concerns_section_path(section.id)
+      selected = find("select#section_monograph_id option[value='#{monograph2.id}']")
+      expect(selected).to be_selected
+    end
+  end
+end

--- a/spec/models/section_spec.rb
+++ b/spec/models/section_spec.rb
@@ -3,9 +3,21 @@ require 'rails_helper'
 describe Section do
   let(:instance) { described_class.new }
   let(:date) { DateTime.now }
+  let(:monograph_id) { '123' }
 
   it "has date_published" do
     instance.date_published = [date]
     expect(instance.date_published).to eq [date]
+  end
+
+  it "has a monograph_id" do
+    instance.monograph_id = monograph_id
+    expect(instance.monograph_id).to eq monograph_id
+  end
+
+  it "indexes the monograph_id" do
+    instance.monograph_id = monograph_id
+    indexed = instance.to_solr
+    expect(indexed['monograph_id_ssim']).to eq [monograph_id]
   end
 end

--- a/spec/presenters/curation_concerns/section_presenter_spec.rb
+++ b/spec/presenters/curation_concerns/section_presenter_spec.rb
@@ -6,7 +6,8 @@ describe CurationConcerns::SectionPresenter do
     { "id" => "qr46r109z",
       "title_tesim" => ["foo bar"],
       "human_readable_type_tesim" => ["Generic Work"],
-      "has_model_ssim" => ["GenericWork"] }
+      "has_model_ssim" => ["GenericWork"],
+      "monograph_id_ssim" => "dr26xx448" }
   end
 
   let(:ability) { nil }
@@ -27,9 +28,4 @@ describe CurationConcerns::SectionPresenter do
     subject { presenter.monograph_label }
     it { is_expected.to eq 'My first monograph' }
   end
-
-  # describe "#monograph_id" do
-  #   subject { presenter.monograph_id }
-  #   it { is_expected.to eq 'my book' }
-  # end
 end


### PR DESCRIPTION
Makes the edit section page's monograph dropdown be set to the section's monograph.

Resolves #187 