### PR TITLE
set umask in umich deploy to staging to allow for group read/write

### DIFF
--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -7,6 +7,9 @@ set :repo_url, ENV.fetch('REPO', 'https://github.com/curationexperts/heliotrope.
 set :deploy_to, ENV.fetch('DIR', '/opt/heliotrope')
 server "#{ENV.fetch('USER')}@#{ENV.fetch('HOST')}", roles: [:web, :app, :db, :puma, :resque_pool]
 
+# ensure umask is set to allow groups to read/write
+SSHKit.config.umask = "0002"
+
 # for distributed architecture, specify the roles & hosts separately:
 # role :web, "#{ENV.fetch('WEB_USER')}@#{ENV.fetch('WEB_HOST')}"
 # role :app, "#{ENV.fetch('APP_USER')}@#{ENV.fetch('APP_HOST')}"

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -10,6 +10,9 @@ server "#{ENV.fetch('USER')}@#{ENV.fetch('HOST')}", roles: [:web, :app, :db, :pu
 # ensure umask is set to allow groups to read/write
 SSHKit.config.umask = "0002"
 
+# prevent permissions issues by using a temp dir under user's home dir
+set :tmp_dir, ENV['TMP'] || '/tmp'
+
 # for distributed architecture, specify the roles & hosts separately:
 # role :web, "#{ENV.fetch('WEB_USER')}@#{ENV.fetch('WEB_HOST')}"
 # role :app, "#{ENV.fetch('APP_USER')}@#{ENV.fetch('APP_HOST')}"

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -11,7 +11,7 @@ server "#{ENV.fetch('USER')}@#{ENV.fetch('HOST')}", roles: [:web, :app, :db, :pu
 SSHKit.config.umask = "0002"
 
 # prevent permissions issues by using a temp dir under user's home dir
-set :tmp_dir, ENV['TMP'] || '/tmp'
+set :tmp_dir, "/tmp/#{ENV.fetch('USER')}"
 
 # for distributed architecture, specify the roles & hosts separately:
 # role :web, "#{ENV.fetch('WEB_USER')}@#{ENV.fetch('WEB_HOST')}"


### PR DESCRIPTION
When deploying from a UM server to nectar this week, I continually ran into permission issues when cap wanted to read or write to `tmp` and other directories. I found you can set the umask in the cap config file: http://stackoverflow.com/questions/21465706/set-umask-for-remote-commands

It would be good if Seth and Conor could test this first before merging. 